### PR TITLE
Предупреждения от pdfLatex

### DIFF
--- a/tex/G2-105.sty
+++ b/tex/G2-105.sty
@@ -249,13 +249,13 @@
   %  перенос в словах-с-дефисом
   \lccode`\-=`\-
   \defaulthyphenchar=127
-  
-  \RequirePackage[english,russian]{babel}
+
+  \RequirePackage{cmap} %теперь из pdf можно копипастить русский текст
   \RequirePackage[T2A]{fontenc} % T1 по этой же пичине, иначе акробату плохо.
   \RequirePackage[\Gost@encoding]{inputenc}
+  \RequirePackage[english,russian]{babel}
   \RequirePackage{ucs} %теперь из pdf можно копипастить русский текст
   \RequirePackage{mathtext}%русские буквы в формулах
-  \RequirePackage{cmap} %теперь из pdf можно копипастить русский текст
   \if@usepscyr
     \RequirePackage[math]{pscyr}
   \fi
@@ -268,7 +268,7 @@
   \RequirePackage{fontspec}
   \RequirePackage{polyglossia}
   \RequirePackage{xecyr}
-  \setmainlanguage[spelling=modern]{russian} 
+  \setmainlanguage[spelling=modern]{russian}
   \setotherlanguage{english}
   \defaultfontfeatures{Mapping=tex-text}
   \setmainfont{CMU Serif}


### PR DESCRIPTION
Избавился от

```
Package babel Warning: No Cyrillic font encoding has been loaded so far.
(babel)                A font encoding should be declared before babel.
(babel)                Default `T2A' encoding will be loaded  on input line 111
```

```
Package babel Warning: No input encoding specified for Russian language on input line 146.
```

```
Package cmap Warning: fontenc already loaded - some fonts may be unprocessed.
```

Остаётся ещё одно предупреждение:

```
Package caption Warning: Unsupported document class (or package) detected,
(caption)                usage of the caption package is not recommended.
See the caption package documentation for explanation.
```

Есть мысли как решается?
