### PR TITLE
Fix \eqref

### DIFF
--- a/tex/G2-105.sty
+++ b/tex/G2-105.sty
@@ -674,7 +674,6 @@
 \RequirePackage{icomma} % "Умная" запятая: $0,2$ --- число, $0, 2$ --- перечисление
 \input{leqno.clo}       % Equation numeration
 
-\renewcommand*\eqref[1]{\ref{#1}} %Было newcommand -- Коротков И.
 \def\@eqnnum{{\theequation}}% убран \normalfont
 
 % Убраны скобки вокруг  \arabic{equation} -- Крищенко В.


### PR DESCRIPTION
Использование `\eqref` для нумерации формул.