### PR TITLE
Use fonts from local folder (fixes #139)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,16 +1,10 @@
 FROM alpine:latest AS font-builder
 
-RUN apk --update add openssl wget unzip \
+RUN apk --update add msttcorefonts-installer \
   && rm -rf /var/cache/apk/* \
-  && mkdir -p /fonts \
-  && cd /fonts \
-  && wget http://astralinux.ru/information/fonts-astra/font-ptastra-serif-ver1003.zip \
-  && wget http://astralinux.ru/information/fonts-astra/font-ptastrasans-ttf-ver1002.zip \
-  && unzip font-ptastra-serif-ver1003.zip \
-  && unzip font-ptastrasans-ttf-ver1002.zip \
-  && rm -rf *.zip \
-  && apk add msttcorefonts-installer \
-  && update-ms-fonts 
+  && update-ms-fonts
+
+COPY ./fonts/*.ttf /fonts/truetype/astra/
 
 FROM debian:bookworm AS doc-builder
 
@@ -39,7 +33,7 @@ RUN chmod -R 644 /usr/share/fonts/truetype/astra/* \
   dia \
   graphviz \
   imagemagick \
-  texlive-extra-utils \ 
+  texlive-extra-utils \
   ghostscript \
   && dpkg-query --showformat='${binary:Package}\n' --show '*-doc' \
   | xargs apt-get -y remove \


### PR DESCRIPTION
Сайт Астры перестал стабильно выдавать шрифты — часто отвечает ошибкой 404 (#139) или присылает битые архивы. 

Я заметил, что эти же шрифты уже есть в репозитории в папке `fonts`, поэтому обновил Dockerfile, чтобы брать их оттуда