### PR TITLE
ci: add GitHub Actions workflow to publish Docker image to GHCR

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -27,7 +27,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract Docker metadata

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,6 +3,7 @@ name: Build and Publish Docker Image
 on:
   push:
     branches: ["7.32-2017-dev"]
+    tags: ["v*"]
   workflow_dispatch:
 
 permissions:
@@ -36,8 +37,8 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           tags: |
             type=ref,event=branch
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
             type=sha,prefix=sha-
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,53 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    branches: ["7.32-2017-dev"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=sha-
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/docker-publish.yml` — автоматическая сборка и публикация Docker-образа в GitHub Container Registry (GHCR) при каждом push в основную ветку и при создании тегов.

## Motivation

Сейчас проект поставляет только `docker/Dockerfile` без готовых образов в публичных реестрах. Это вынуждает каждого пользователя собирать образ вручную перед использованием в CI/CD. Предлагаемый workflow автоматизирует публикацию, после чего образ доступен напрямую:

```
docker pull ghcr.io/latex-g7-32/latex-g7-32:latest
```

## What the workflow does

1. Запускается при push в ветку `7.32-2017-dev` и при `workflow_dispatch`.
2. Собирает multi-stage образ из `docker/Dockerfile` (контекст — корень репозитория, чтобы скопировать шрифты из `fonts/`).
3. Публикует в `ghcr.io/<owner>/<repo>` с тегами:
   - `latest` — при push в ветку по умолчанию;
   - `<branch-name>` — по имени ветки;
   - `vX.Y`, `vX.Y.Z` — при семантических тегах;
   - `sha-<short-sha>` — для точной воспроизводимости.
4. Использует GitHub Actions cache (`type=gha`) для ускорения повторных сборок.

## Notes

- Образ публикуется под именем `ghcr.io/${{ github.repository }}`, поэтому в форках он автоматически оказывается в пространстве имён форка, не затрагивая оригинальный реестр.
- Права минимально необходимые: `contents: read`, `packages: write`.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)